### PR TITLE
Closes #14

### DIFF
--- a/meantweets/meantweets/MainView.swift
+++ b/meantweets/meantweets/MainView.swift
@@ -56,6 +56,7 @@ class MainView: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpUI()
+        enableDismissKeyboard()
     }
     
     // MARK: - UI Setup
@@ -91,10 +92,21 @@ class MainView: UIViewController {
         submitButton.addTarget(self, action: #selector(didTapSubmit), for: .touchUpInside)
     }
 
+    // MARK: - Tap Gesture
+    
+    func enableDismissKeyboard() {
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        view.addGestureRecognizer(tapGestureRecognizer)
+    }
+    
+    
     // MARK: - Selectors
     
     @objc func didTapSubmit() {
         present(ResultsView(handle: searchBar.text ?? ""), animated: true, completion: nil)
     }
     
+    @objc func dismissKeyboard() {
+        searchBar.resignFirstResponder()
+    }
 }


### PR DESCRIPTION
The keyboard used to type in a desired Twitter handle was dismissable on an emulator, but not a physical device.

This PR adds required code to dismiss the keyboard so the "submit" button can be pressed and main functionality executed.